### PR TITLE
Hotfix save value

### DIFF
--- a/components/MultipleSelectList.tsx
+++ b/components/MultipleSelectList.tsx
@@ -273,21 +273,13 @@ const MultipleSelectList: React.FC<MultipleSelectListProps> = ({
                                                         let sv = [...selectedval];
                                                         sv.splice(existing,1) 
                                                         setSelectedVal(sv);
-
-
-                                                        setSelected((val: any) => {
-                                                            let temp = [...val];
-                                                            temp.splice(existing,1) 
-                                                            return temp;
-                                                        });
+                                                        setSelected(sv);
                                                         
                                                         // onSelect()
                                                     }else{
+                                                        let sv = [...new Set([...selectedval,value])];
                                                         if(save === 'value'){
-                                                            setSelected((val: any) => {
-                                                                let temp = [...new Set([...val,value])];
-                                                                return temp;
-                                                            })
+                                                            setSelected(sv)
                                                         }else{
                                                             setSelected((val: any) => {
                                                                 let temp = [...new Set([...val,key])];
@@ -295,10 +287,7 @@ const MultipleSelectList: React.FC<MultipleSelectListProps> = ({
                                                             })
                                                         }
                                                        
-                                                        setSelectedVal((val: any )=> {
-                                                            let temp = [...new Set([...val,value])];
-                                                            return temp;
-                                                        })
+                                                        setSelectedVal(sv);
                                     
                                                         
                                                         // onSelect()

--- a/components/SelectList.tsx
+++ b/components/SelectList.tsx
@@ -92,7 +92,7 @@ const SelectList: React.FC<SelectListProps> =  ({
 
         if(defaultOption && _firstRender && defaultOption.key != undefined){
             oldOption.current = defaultOption.key
-            setSelected(defaultOption.key);
+            setSelected(defaultOption.value);
             setSelectedVal(defaultOption.value);
         }
         


### PR DESCRIPTION
Noticed odd behavior when finishing up the Toast card when I was testing server responses for prayer requests. Key names were being saved instead of their values for SelectList, and anonymous functions were being saved for MultiSelectLists.

Fixed both.